### PR TITLE
fix typo and missing parentheses in FlatMap* examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Spawns a new stream from a function for each event in the source stream. The ret
 
 ```dart
 var controller = new StreamController();
-var flapMapped = controller.stream.transform(new FlatMap((value) => new Stream.fromIterable([value + 1]));
+var flatMapped = controller.stream.transform(new FlatMap((value) => new Stream.fromIterable([value + 1])));
 
 flatMapped.listen(print);
 
@@ -228,7 +228,7 @@ Similar to `FlatMap`, but instead of including events from all spawned streams, 
 
 ```dart
 var controller = new StreamController();
-var latest = controller.stream.transform(new FlatMapLatest((value) => new Stream.fromIterable([value + 1]));
+var latest = controller.stream.transform(new FlatMapLatest((value) => new Stream.fromIterable([value + 1])));
 
 latest.listen(print);
 

--- a/lib/src/flat_map.dart
+++ b/lib/src/flat_map.dart
@@ -8,7 +8,7 @@ part of stream_transformers;
 /// **Example:**
 ///
 ///     var controller = new StreamController();
-///     var flapMapped = controller.stream.transform(new FlatMap((value) => new Stream.fromIterable([value + 1]));
+///     var flatMapped = controller.stream.transform(new FlatMap((value) => new Stream.fromIterable([value + 1])));
 ///
 ///     flatMapped.listen(print);
 ///

--- a/lib/src/flat_map_latest.dart
+++ b/lib/src/flat_map_latest.dart
@@ -7,7 +7,7 @@ part of stream_transformers;
 /// **Example:**
 ///
 ///     var controller = new StreamController();
-///     var latest = controller.stream.transform(new FlatMapLatest((value) => new Stream.fromIterable([value + 1]));
+///     var latest = controller.stream.transform(new FlatMapLatest((value) => new Stream.fromIterable([value + 1])));
 ///
 ///     latest.listen(print);
 ///


### PR DESCRIPTION
Fixed in source files and README.
